### PR TITLE
Fix colophon artist wikipedia link

### DIFF
--- a/src/epub/text/colophon.xhtml
+++ b/src/epub/text/colophon.xhtml
@@ -25,7 +25,7 @@
 			<p>The cover page is adapted from<br/>
 			<i epub:type="se:name.visual-art.painting">Still Life: Tea Set</i>,<br/>
 			a painting completed around 1783 by<br/>
-			<a href="https://en.wikipedia.org/wiki/Henri_Fantin-Latour">Jean-Étienne Liotard</a>.<br/>
+			<a href="https://en.wikipedia.org/wiki/Jean-%C3%89tienne_Liotard">Jean-Étienne Liotard</a>.<br/>
 			The cover and title pages feature the<br/>
 			<span epub:type="se:name.visual-art.typeface">League Spartan</span> and <span epub:type="se:name.visual-art.typeface">Sorts Mill Goudy</span><br/>
 			typefaces created in 2014 and 2009 by<br/>


### PR DESCRIPTION
[Jean-Étienne Liotard](https://en.wikipedia.org/wiki/Jean-%C3%89tienne_Liotard)’s link was pointing to [Henri Fantin-Latour](https://en.wikipedia.org/wiki/Henri_Fantin-Latour).