### PR TITLE
Mark up abbreviations within the prescription

### DIFF
--- a/src/epub/text/chapter-12.xhtml
+++ b/src/epub/text/chapter-12.xhtml
@@ -76,12 +76,12 @@
 				<table>
 					<tbody>
 						<tr>
-							<td>Strychninae Sulph.</td>
+							<td>Strychninae <abbr>Sulph.</abbr></td>
 							<td>. . . . . .</td>
 							<td>gr. I</td>
 						</tr>
 						<tr>
-							<td>Potass Bromide</td>
+							<td><abbr>Potass.</abbr> Bromide</td>
 							<td>. . . . . .</td>
 							<td>³vi</td>
 						</tr>


### PR DESCRIPTION
The prescription in chapter 12 currently includes these two lines:

    <td>Strychninae Sulph.</td>
    <td>Potass Bromide</td>

I don’t believe the period after “sulphide” is in the original text; the dot there is actually part of a leader. It probably *should* have a dot, and be marked up as `<abbr>`. But if we do it for ‘sulph,’ we should do it for ‘potass’ as well.